### PR TITLE
Disable apt repo for instana

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,6 +50,7 @@ class instana_agent(
   String        $instana_agent_mirror_auth_password = '',
   String        $instana_agent_mirror_urls_release  = '',
   String        $instana_agent_mirror_urls_shared   = '',
+  Boolean       $instana_agent_manage_repro         = true,
 ) {
 
   if ($instana_agent_key == '') {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -74,5 +74,6 @@ class instana_agent(
 
   service { 'instana-agent':
     ensure  => 'running',
+    enable  => 'true'
   }
 }


### PR DESCRIPTION
We added the instana-agent package to our existing apt repository and do not use a mirror. Therefore we added a switch to disable the managed repository.